### PR TITLE
Changed Description and Link

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -14,13 +14,13 @@
     <extension point="xbmc.addon.metadata">
         <summary lang="en">Jupiter Broadcasting video addon</summary>
         <summary lang="bg">Видео добавка за Jupiter Broadcasting</summary>
-        <description lang="en">Watch shows from the Jupiter Broadcasting Network including the Linux Action Show, TechSNAP, FauxShow, Coder Radio, Women's Tech Radio and more.</description>
-        <description lang="bg">Гледайте предавания от мрежата на Jupiter Broadcasting: Linux Action Show, TechSNAP, FauxShow, Coder Radio, Women's Tech Radio и други.</description>
+        <description lang="en">Watch shows from the Jupiter Broadcasting Network including Linux Action News, TechSNAP, Ask Noah, Coder Radio,  and more.</description>
+        <description lang="bg">Гледайте предавания от мрежата на Jupiter Broadcasting: Linux Action News, TechSNAP, Ask Noah, Coder Radio, и други.</description>
         <disclaimer lang="en">For more information, visit JupiterBroadcasting.com.</disclaimer>
         <disclaimer lang="bg">За повече информация посетете www.JupiterBroadcasting.com</disclaimer>
         <license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>
         <website>http://jupiterbroadcasting.com</website>
-        <source>http://github.com/robloach/plugin.video.jupiterbroadcasting</source>
+        <source>https://github.com/JupiterBroadcasting/plugin.video.jupiterbroadcasting</source>
         <platform>all</platform>
         <language>en</language>
     </extension>


### PR DESCRIPTION
Changes that address https://github.com/JupiterBroadcasting/plugin.video.jupiterbroadcasting/issues/82 

Change link to point to new link of the addon on Github

-------------
I am half blurry-eyed at the moment but i think that is all that was needed. 

One more thing .. I am not touching the changelog file to add these additions ... if you want me to do so and then resubmit the PR just let me know ... the IDEA is to not add an un-needed "updated changelog"  commit ... OR if its possible to update the changelog and merge this commit then squash them together ... that'd be fine too ... again the IDEA is not to have another commit for just updating the changelog.